### PR TITLE
3 有料会員の場合のリクエスト数validation除却

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -399,6 +399,65 @@ async fn verify_email_and_login(request: VerifyEmailAndLoginRequest) -> Result<S
         .map_err(|e| format!("メール認証とログインに失敗しました: {}", e))
 }
 
+// プレミアム会員かどうかをチェックする関数
+async fn check_premium_membership(app_handle: &tauri::AppHandle) -> Result<bool, String> {
+    let store = app_handle.store("auth.json").map_err(|e| {
+        format!("認証ストアの取得に失敗しました: {}", e)
+    })?;
+
+    let tokens = match store.get("tokens") {
+        Some(tokens) => tokens,
+        None => return Ok(false), // 認証されていない場合は無料
+    };
+
+    let access_token = match tokens.get("access_token").and_then(|v| v.as_str()) {
+        Some(token) => token,
+        None => return Ok(false), // アクセストークンがない場合は無料
+    };
+
+    // Cognitoサービスを初期化
+    let cognito_service = match create_cognito_service().await {
+        Ok(service) => service,
+        Err(e) => {
+            println!("Cognitoサービスの初期化に失敗: {}", e);
+            return Ok(false); // エラーの場合は安全側に倒して無料として扱う
+        }
+    };
+
+    // ユーザー属性を取得
+    let user_attrs = match cognito_service.get_user_attributes(access_token).await {
+        Ok(attrs) => attrs,
+        Err(e) => {
+            println!("ユーザー属性の取得に失敗: {}", e);
+            return Ok(false); // エラーの場合は無料として扱う
+        }
+    };
+
+    // membership_statusをチェック
+    if let Some(membership_status) = user_attrs.membership_status {
+        if membership_status == "premium" || membership_status == "business" {
+            // 有料プランの場合、有効期限もチェック
+            if let Some(expires_at) = user_attrs.subscription_expires_at {
+                match DateTime::parse_from_rfc3339(&expires_at) {
+                    Ok(expiry) => {
+                        let now = Utc::now();
+                        return Ok(expiry > now);
+                    }
+                    Err(_) => {
+                        println!("無効な有効期限形式: {}", expires_at);
+                        return Ok(false);
+                    }
+                }
+            } else {
+                // 有効期限が設定されていない有料プランは無効
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(false) // デフォルトは無料
+}
+
 // 認証状態をチェックするヘルパー関数
 fn is_user_authenticated(app_handle: &tauri::AppHandle) -> bool {
     let store = match app_handle.store("auth.json") {
@@ -430,8 +489,16 @@ async fn convert_text(
     type_: &str,
     app_handle: tauri::AppHandle,
 ) -> Result<String, String> {
-    // 認証済みユーザーは制限をスキップ
-    if !is_user_authenticated(&app_handle) {
+    // プレミアム会員は制限をスキップ
+    let is_premium = match check_premium_membership(&app_handle).await {
+        Ok(is_premium) => is_premium,
+        Err(e) => {
+            println!("会員ステータスチェックでエラー: {}。無料として処理します。", e);
+            false
+        }
+    };
+
+    if !is_premium {
         // 利用回数制限のためのストア取得
         let store = app_handle.store("usage.json").map_err(|e| {
             serde_json::json!({"type": "store_error", "message": e.to_string()}).to_string()

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -29,96 +29,53 @@ let stripeConfig: StripeConfig | null = null;
 // Tauri API が利用可能になるまで待つ関数
 async function waitForTauriApi(maxWaitTime = 20000): Promise<boolean> {
   const startTime = Date.now();
-  let attempt = 0;
 
   // User Agentでタウリアプリかどうかを判定
   const isTauriApp = navigator.userAgent.includes('tauri');
-  console.log('User Agent:', navigator.userAgent);
-  console.log('Is Tauri App:', isTauriApp);
-
   if (!isTauriApp) {
-    console.log('ブラウザで実行されています。Tauriアプリのウィンドウで実行してください。');
     return false;
   }
 
   while (Date.now() - startTime < maxWaitTime) {
-    attempt++;
-    console.log(`Tauri API チェック試行 #${attempt}`);
-    console.log('window:', typeof window);
-    console.log('window.__TAURI__:', typeof (window as any).__TAURI__);
-    console.log('__TAURI__ in window:', '__TAURI__' in window);
-    console.log('window.location.href:', window.location.href);
-
     if (typeof window !== 'undefined') {
-      console.log('window.__TAURI__ exists:', !!(window as any).__TAURI__);
-      console.log('window.__TAURI_INTERNALS__ exists:', !!(window as any).__TAURI_INTERNALS__);
-      console.log('window.__TAURI_PLUGIN_INVOKE__ exists:', !!(window as any).__TAURI_PLUGIN_INVOKE__);
-
       // Tauri v2では __TAURI__ オブジェクトと invoke 関数の存在を確認
       if ('__TAURI__' in window && (window as any).__TAURI__ && typeof invoke === 'function') {
-        console.log('Tauri API が利用可能になりました');
         return true;
       }
 
       // 代替チェック: invoke関数が直接利用可能かどうか
       try {
         if (typeof invoke === 'function') {
-          console.log('invoke関数が直接利用可能です');
           return true;
         }
       } catch (e) {
-        console.log('invoke関数チェックエラー:', e);
+        // エラーは無視して次の試行へ
       }
     }
 
-    console.log(`Tauri API を待機中... (${Date.now() - startTime}ms経過)`);
     await new Promise(resolve => setTimeout(resolve, 300));
   }
-
-  console.log('Tauri API の待機がタイムアウトしました');
-  console.log('最終状態:');
-  console.log('  User Agent:', navigator.userAgent);
-  console.log('  Location:', window.location.href);
-  console.log('  window:', typeof window);
-  console.log('  __TAURI__ in window:', '__TAURI__' in window);
-  console.log('  window.__TAURI__:', typeof (window as any).__TAURI__);
-  console.log('  invoke function:', typeof invoke);
   return false;
 }
 
 // Rust側からStripe設定を取得
 async function getStripeConfig(): Promise<StripeConfig> {
-  console.log('getStripeConfig関数が呼び出されました');
-
   if (stripeConfig) {
-    console.log('キャッシュされたStripe設定を返します');
     return stripeConfig;
   }
 
   try {
-    console.log('Tauriアプリの可用性をチェック中...');
-    console.log('window:', typeof window);
-    console.log('__TAURI__ in window:', '__TAURI__' in window);
-
-    // Tauri API が利用可能になるまで待つ（デバッグ用に一時的にスキップ）
-    console.log('Tauri APIチェックを開始します...');
+    // 直接 invoke 関数を試してみる
     try {
-      // 直接 invoke 関数を試してみる
-      console.log('invoke関数の直接呼び出しを試行します...');
       stripeConfig = await invoke<StripeConfig>('get_stripe_config');
-      console.log('invoke関数の直接呼び出しが成功しました:', stripeConfig);
     } catch (directInvokeError) {
-      console.log('invoke関数の直接呼び出しが失敗しました:', directInvokeError);
-
       // 通常の待機処理を実行
       const tauriAvailable = await waitForTauriApi();
       if (!tauriAvailable) {
         throw new Error('Tauri app not available. フロントエンドのみでは決済処理はサポートされていません。');
       }
 
-      console.log('待機後のinvoke関数呼び出しを試行します...');
       stripeConfig = await invoke<StripeConfig>('get_stripe_config');
-      console.log('待機後のinvoke関数呼び出しが成功しました:', stripeConfig);
     }
 
     // stripeConfigは既に上で設定されているので、ここでは設定チェックのみ
@@ -190,33 +147,16 @@ export async function createCheckoutSession(data: CreateCheckoutSessionData): Pr
 
 // プランタイプからStripe Price IDを取得
 export async function getPriceId(planType: PlanType): Promise<string> {
-  console.log('getPriceId関数が呼び出されました。プランタイプ:', planType);
-
-  // Tauri環境の詳細デバッグ
-  console.log('=== Tauri環境デバッグ ===');
-  console.log('User Agent:', navigator.userAgent);
-  console.log('Location:', window.location);
-  console.log('Window object keys:', Object.keys(window));
-  console.log('window.__TAURI__ exists:', '__TAURI__' in window);
-  console.log('window.__TAURI__ type:', typeof (window as any).__TAURI__);
-  console.log('window.__TAURI__ value:', (window as any).__TAURI__);
-  console.log('window.__TAURI_INTERNALS__ exists:', '__TAURI_INTERNALS__' in window);
-  console.log('========================');
-
   if (planType === 'free') {
     throw new Error('Free plan does not have a price ID');
   }
 
-  console.log('getStripeConfigを呼び出して設定を取得中...');
   const config = await getStripeConfig();
-  console.log('Stripe設定取得成功。price_weekly:', config.price_weekly, 'price_monthly:', config.price_monthly);
 
   switch (planType) {
     case 'weekly':
-      console.log('週間プランの価格IDを返します:', config.price_weekly);
       return config.price_weekly;
     case 'monthly':
-      console.log('月間プランの価格IDを返します:', config.price_monthly);
       return config.price_monthly;
     default:
       throw new Error(`Unknown plan type: ${planType}`);


### PR DESCRIPTION
## 📝 概要
有料会員の無制限アクセス機能を実装します。
Cognitoカスタム属性から会員ステータスを取得し、プレミアム会員の回数制限をバイパスする仕組みを構築します。

## 🎯 目的
- 有料会員（premium/business）の回数制限解除
- Cognitoからのリアルタイム会員ステータス取得
- 安全で信頼性の高い認証システムの構築

## 🔧 変更内容

### 新機能: プレミアム会員判定 (`src-tauri/src/lib.rs`)
```rust
async fn check_premium_membership(app_handle: &tauri::AppHandle) -> Result<bool, String>
```

**機能詳細:**
- 認証トークンからCognitoユーザー属性を取得
- `membership_status`が`premium`または`business`かを確認
- サブスクリプション有効期限の検証
- エラー時は安全側（無料）として処理

### コア機能の更新: 制限チェックロジック
```rust
// 変更前
if !is_user_authenticated(&app_handle) {
    // 制限チェック
}

// 変更後  
let is_premium = check_premium_membership(&app_handle).await?;
if !is_premium {
    // 制限チェック（無料会員のみ）
}
```

## 🚀 実現される機能
- ✅ **プレミアム会員**: 回数制限なしで無制限利用
- ✅ **無料会員**: 既存の回数制限（20回/日）を維持
- ✅ **エラー時フォールバック**: ネットワークエラー等の場合は無料として処理
- ✅ **リアルタイム検証**: 毎回Cognitoから最新の会員状態を取得

## 🔒 セキュリティ考慮
- アクセストークンによる認証済み確認
- 有効期限の厳密なチェック
- エラー時の安全側フォールバック
- 不正な会員ステータスの適切な処理

## 🎯 対象ユーザー
| 会員ステータス | 制限 | 説明 |
|-------------|------|------|
| `free` | 20回/日 | 既存の無料プラン |
| `premium` | 無制限 | 週額・月額プラン |
| `business` | 無制限 | 将来的な法人プラン |

## ✅ テスト項目
- [ ] 無料会員の制限が正常に動作することを確認
- [ ] プレミアム会員の無制限アクセスを確認
- [ ] 有効期限切れの場合の制限復活を確認
- [ ] ネットワークエラー時のフォールバック動作を確認
- [ ] 不正な認証トークン時の安全な処理を確認

## 📊 影響範囲
- **リスク**: 中
- **影響範囲**: コア機能の制限ロジック
- **後方互換性**: あり（無料会員は既存動作を維持）

## 🔄 パフォーマンス
- Cognitoへの問い合わせは各API呼び出し時に実行
- 将来的にはキャッシュ機能の追加を検討

## 📎 関連Issue
- #XXX 会員ステータス管理機能の実装
- #XXX 有料プランの無制限利用機能

---
**レビューポイント**
- セキュリティ面での検証ロジック
- エラーハンドリングの適切性
- パフォーマンスへの影響
- 無料会員への影響の有無